### PR TITLE
feat: set env variables to microcks deployment

### DIFF
--- a/operator/src/main/java/io/github/microcks/operator/base/resources/MicrocksDeploymentDependentResource.java
+++ b/operator/src/main/java/io/github/microcks/operator/base/resources/MicrocksDeploymentDependentResource.java
@@ -137,6 +137,20 @@ public class MicrocksDeploymentDependentResource extends CRUDKubernetesDependent
                .endTemplate()
             .endSpec();
 
+      microcks.getSpec().getMicrocks().getEnv().forEach(env -> {
+         builder.editSpec()
+               .editTemplate()
+                 .editSpec()
+                    .editFirstContainer()
+                        .addNewEnv()
+                            .withName(env.getName())
+                            .withValue(env.getValue())
+                        .endEnv()
+                    .endContainer()
+                 .endSpec()
+               .endTemplate().endSpec();
+      });
+
       if (spec.getKeycloak().isInstall() || spec.getKeycloak().getPrivateUrl() != null) {
          builder.editSpec()
                .editTemplate()

--- a/operator/src/main/java/io/github/microcks/operator/base/resources/MicrocksDeploymentDependentResource.java
+++ b/operator/src/main/java/io/github/microcks/operator/base/resources/MicrocksDeploymentDependentResource.java
@@ -98,6 +98,7 @@ public class MicrocksDeploymentDependentResource extends CRUDKubernetesDependent
                   .editSpec()
                      .editFirstContainer()
                         .withImage(spec.getMicrocks().getImage().getCoordinates())
+                        .addAllToEnv(spec.getMicrocks().getEnv())
                         .addNewEnv()
                            .withName("SPRING_PROFILES_ACTIVE")
                            .withValue("prod")
@@ -136,20 +137,6 @@ public class MicrocksDeploymentDependentResource extends CRUDKubernetesDependent
                   .endSpec()
                .endTemplate()
             .endSpec();
-
-      microcks.getSpec().getMicrocks().getEnv().forEach(env -> {
-         builder.editSpec()
-               .editTemplate()
-                 .editSpec()
-                    .editFirstContainer()
-                        .addNewEnv()
-                            .withName(env.getName())
-                            .withValue(env.getValue())
-                        .endEnv()
-                    .endContainer()
-                 .endSpec()
-               .endTemplate().endSpec();
-      });
 
       if (spec.getKeycloak().isInstall() || spec.getKeycloak().getPrivateUrl() != null) {
          builder.editSpec()


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

This PR applies env variables to the Microcks deployment.

```yaml
apiVersion: microcks.io/v1alpha1
kind: Microcks
metadata:
  name: microcks
spec:
  version: 1.10.0
  microcks:
    url: microcks.docker.localhost
    env:
      - name: KEYCLOAK_ENABLED
        value: "false"
  keycloak:
    install: false
    url: keycloak.docker.localhost
```

In the example, the env variable `KEYCLOAK_ENABLED` was not set on the microcks deployment, with the fix, this variable is created on the microcks deployment.

### Related issue(s)

