### PR TITLE
feat: allow configuring openai api url in microcks custom resource

### DIFF
--- a/api/src/main/java/io/github/microcks/operator/api/base/v1alpha1/OpenAISpec.java
+++ b/api/src/main/java/io/github/microcks/operator/api/base/v1alpha1/OpenAISpec.java
@@ -44,6 +44,9 @@ public class OpenAISpec {
    @JsonPropertyDescription("The maximum number of tokens to generate/transfer")
    private int maxTokens;
 
+   @JsonPropertyDescription("The OpenAI API URL to use")
+   private String apiUrl; 
+
    public String getApiKey() {
       return apiKey;
    }
@@ -74,5 +77,13 @@ public class OpenAISpec {
 
    public void setMaxTokens(int maxTokens) {
       this.maxTokens = maxTokens;
+   }
+
+   public String getApiUrl(){
+      return apiUrl;
+   }
+
+   public void setApiUrl(String apiUrl){
+      this.apiUrl = apiUrl;
    }
 }

--- a/deploy/crd/microckses.microcks.io-v1.yml
+++ b/deploy/crd/microckses.microcks.io-v1.yml
@@ -9,1408 +9,1411 @@ spec:
     kind: Microcks
     plural: microckses
     shortNames:
-      - microcks
+    - microcks
     singular: microcks
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          properties:
-            spec:
-              properties:
-                commonAffinities:
-                  description: Common affinities added to all managed resources
-                  properties:
-                    nodeAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              preference:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                type: integer
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          properties:
-                            nodeSelectorTerms:
-                              items:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    type: array
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    podAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              podAffinityTerm:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  matchLabelKeys:
-                                    items:
-                                      type: string
-                                    type: array
-                                  mismatchLabelKeys:
-                                    items:
-                                      type: string
-                                    type: array
-                                  namespaceSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                type: object
-                              weight:
-                                type: integer
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              matchLabelKeys:
-                                items:
-                                  type: string
-                                type: array
-                              mismatchLabelKeys:
-                                items:
-                                  type: string
-                                type: array
-                              namespaceSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              podAffinityTerm:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  matchLabelKeys:
-                                    items:
-                                      type: string
-                                    type: array
-                                  mismatchLabelKeys:
-                                    items:
-                                      type: string
-                                    type: array
-                                  namespaceSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                type: object
-                              weight:
-                                type: integer
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              matchLabelKeys:
-                                items:
-                                  type: string
-                                type: array
-                              mismatchLabelKeys:
-                                items:
-                                  type: string
-                                type: array
-                              namespaceSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-                commonAnnotations:
-                  additionalProperties:
-                    type: string
-                  description: Common annotations added to all managed resources
-                  type: object
-                commonLabels:
-                  additionalProperties:
-                    type: string
-                  description: Common labels to add to all managed resources
-                  type: object
-                commonTolerations:
-                  description: Common tolerations added to all managed resources
-                  items:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              commonAffinities:
+                description: Common affinities added to all managed resources
+                properties:
+                  nodeAffinity:
                     properties:
-                      effect:
-                        type: string
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      tolerationSeconds:
-                        type: integer
-                      value:
-                        type: string
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            preference:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              type: integer
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        properties:
+                          nodeSelectorTerms:
+                            items:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                        type: object
                     type: object
-                  type: array
-                features:
-                  description: Configuration of optional features in Microcks
+                  podAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            podAffinityTerm:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                matchLabelKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                mismatchLabelKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              type: object
+                            weight:
+                              type: integer
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                            mismatchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                            namespaceSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            namespaces:
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            podAffinityTerm:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                matchLabelKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                mismatchLabelKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              type: object
+                            weight:
+                              type: integer
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                            mismatchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                            namespaceSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            namespaces:
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              commonAnnotations:
+                additionalProperties:
+                  type: string
+                description: Common annotations added to all managed resources
+                type: object
+              commonLabels:
+                additionalProperties:
+                  type: string
+                description: Common labels to add to all managed resources
+                type: object
+              commonTolerations:
+                description: Common tolerations added to all managed resources
+                items:
                   properties:
-                    aiCopilot:
-                      description: Configuration for AI Copilot related features
-                      properties:
-                        enabled:
-                          description: Enable/disable this feature. Default is false
-                          type: boolean
-                        implementation:
-                          description: The implementation to use for AI Copilot feature
-                          type: string
-                        openai:
-                          description: Configuration of OpenAI access
+                    effect:
+                      type: string
+                    key:
+                      type: string
+                    operator:
+                      type: string
+                    tolerationSeconds:
+                      type: integer
+                    value:
+                      type: string
+                  type: object
+                type: array
+              features:
+                description: Configuration of optional features in Microcks
+                properties:
+                  aiCopilot:
+                    description: Configuration for AI Copilot related features
+                    properties:
+                      enabled:
+                        description: Enable/disable this feature. Default is false
+                        type: boolean
+                      implementation:
+                        description: The implementation to use for AI Copilot feature
+                        type: string
+                      openai:
+                        description: Configuration of OpenAI access
+                        properties:
+                          apiKey:
+                            description: The OpenAI API key to use
+                            type: string
+                          apiUrl:
+                            description: The OpenAI API URL to use
+                            type: string
+                          maxTokens:
+                            description: The maximum number of tokens to generate/transfer
+                            type: integer
+                          model:
+                            description: The model to use for OpenAI API calls
+                            type: string
+                          timeout:
+                            description: The timeout for OpenAI API calls
+                            type: integer
+                        type: object
+                    type: object
+                  async:
+                    description: Configuration for asynchronous features
+                    properties:
+                      amqp:
+                        description: Configuration of AMQP broker access
+                        properties:
+                          password:
+                            description: The password to use for authenticating to
+                              the broker
+                            type: string
+                          url:
+                            description: The URL to use for connecting to the broker
+                            type: string
+                          username:
+                            description: The username to use for authenticating to
+                              the broker
+                            type: string
+                        type: object
+                      defaultAvroEncoding:
+                        description: Default Avro encoding mode for publishing mock
+                          messages
+                        enum:
+                        - RAW
+                        - REGISTRY
+                        type: string
+                      defaultBinding:
+                        description: Default protocol binding to use if no specified
+                          in AsyncAPI document
+                        type: string
+                      defaultFrequency:
+                        description: Default frequency for publishing async mock messages
+                        type: integer
+                      enabled:
+                        description: Enable/disable this feature. Default is false
+                        type: boolean
+                      env:
+                        description: Environment variables for Async Minion component
+                        items:
                           properties:
-                            apiKey:
-                              description: The OpenAI API key to use
+                            name:
                               type: string
-                            maxTokens:
-                              description: The maximum number of tokens to generate/transfer
-                              type: integer
-                            model:
-                              description: The model to use for OpenAI API calls
+                            value:
                               type: string
-                            timeout:
-                              description: The timeout for OpenAI API calls
-                              type: integer
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  type: object
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  type: object
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                              type: object
                           type: object
-                      type: object
-                    async:
-                      description: Configuration for asynchronous features
-                      properties:
-                        amqp:
-                          description: Configuration of AMQP broker access
-                          properties:
-                            password:
-                              description: The password to use for authenticating to
-                                the broker
-                              type: string
-                            url:
-                              description: The URL to use for connecting to the broker
-                              type: string
-                            username:
-                              description: The username to use for authenticating to
-                                the broker
-                              type: string
-                          type: object
-                        defaultAvroEncoding:
-                          description: Default Avro encoding mode for publishing mock
-                            messages
-                          enum:
-                            - RAW
-                            - REGISTRY
-                          type: string
-                        defaultBinding:
-                          description: Default protocol binding to use if no specified
-                            in AsyncAPI document
-                          type: string
-                        defaultFrequency:
-                          description: Default frequency for publishing async mock messages
-                          type: integer
-                        enabled:
-                          description: Enable/disable this feature. Default is false
-                          type: boolean
-                        env:
-                          description: Environment variables for Async Minion component
-                          items:
+                        type: array
+                      googlepubsub:
+                        description: Configuration of Google PubSub access
+                        properties:
+                          project:
+                            description: The Google Cloud Platform (GCP) project to
+                              use for connecting to PubSub broker
+                            type: string
+                          serviceAccountSecretRef:
+                            description: A Secret reference holding the GCP serviceAccount
+                              authentication token JSON file
                             properties:
+                              additionalProperties:
+                                additionalProperties:
+                                  type: object
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               name:
                                 type: string
-                              value:
-                                type: string
-                              valueFrom:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      image:
+                        description: The container image to use for Async Minion component
+                        properties:
+                          digest:
+                            description: The digest of the image
+                            type: string
+                          registry:
+                            description: "The registry where to pull this image (docker.io,\
+                              \ quay.io, internal one...)"
+                            type: string
+                          repository:
+                            description: The repository name of the image
+                            type: string
+                          tag:
+                            description: The tag of the image
+                            type: string
+                        type: object
+                      kafka:
+                        description: Configuration of Kafka broker access and/or install
+                        properties:
+                          authentication:
+                            description: Specification of authentication method when
+                              using external Kafka
+                            properties:
+                              keystoreSecretRef:
+                                description: Reference to Secret holding client private
+                                  key when using MTLS
                                 properties:
-                                  configMapKeyRef:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
+                                  additionalProperties:
+                                    additionalProperties:
+                                      type: object
                                     type: object
-                                  fieldRef:
-                                    properties:
-                                      apiVersion:
-                                        type: string
-                                      fieldPath:
-                                        type: string
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  name:
+                                    type: string
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              keystoreType:
+                                description: Type of keystore where to find private
+                                  key when using MTLS. PKCS12 and JKS are supported
+                                type: string
+                              saslJaasConfig:
+                                description: Additional JAAS config for SASL_TLS authentication
+                                  type
+                                type: string
+                              saslMechanism:
+                                description: SASL mechanism used when using SASL_TLS
+                                  authentication type
+                                type: string
+                              truststoreSecretRef:
+                                description: Reference to Secret holding cluster certificate
+                                  for TLS transport
+                                properties:
+                                  additionalProperties:
+                                    additionalProperties:
+                                      type: object
                                     type: object
-                                  resourceFieldRef:
-                                    properties:
-                                      containerName:
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        type: string
-                                    type: object
-                                  secretKeyRef:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  name:
+                                    type: string
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              truststoreType:
+                                description: Type of truststore where to find cluster
+                                  certificate for TLS transport. PKCS12 and JKS are
+                                  supported
+                                type: string
+                              type:
+                                description: Type of authentication method for connecting
+                                  to external Kafka broker
+                                enum:
+                                - NONE
+                                - SASL_SSL
+                                - SSL
+                                type: string
+                            type: object
+                          ingressClassName:
+                            description: "When exposed via ingress, sets the ingressClassName\
+                              \ property in the Ingress resources"
+                            type: string
+                          install:
+                            description: Install Kafka broker or reuse an existing
+                              instance? Default to true
+                            type: boolean
+                          persistent:
+                            description: Use persistent storage or ephemeral one?
+                              Default to false
+                            type: boolean
+                          resources:
+                            description: Kubernetes resource requirements for Kafka
+                              broker
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
                                 type: object
                             type: object
-                          type: array
-                        googlepubsub:
-                          description: Configuration of Google PubSub access
-                          properties:
-                            project:
-                              description: The Google Cloud Platform (GCP) project to
-                                use for connecting to PubSub broker
-                              type: string
-                            serviceAccountSecretRef:
-                              description: A Secret reference holding the GCP serviceAccount
-                                authentication token JSON file
-                              properties:
-                                additionalProperties:
-                                  additionalProperties:
-                                    type: object
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                name:
-                                  type: string
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                        image:
-                          description: The container image to use for Async Minion component
-                          properties:
-                            digest:
-                              description: The digest of the image
-                              type: string
-                            registry:
-                              description: "The registry where to pull this image (docker.io,\
-                              \ quay.io, internal one...)"
-                              type: string
-                            repository:
-                              description: The repository name of the image
-                              type: string
-                            tag:
-                              description: The tag of the image
-                              type: string
-                          type: object
-                        kafka:
-                          description: Configuration of Kafka broker access and/or install
-                          properties:
-                            authentication:
-                              description: Specification of authentication method when
-                                using external Kafka
-                              properties:
-                                keystoreSecretRef:
-                                  description: Reference to Secret holding client private
-                                    key when using MTLS
-                                  properties:
-                                    additionalProperties:
-                                      additionalProperties:
-                                        type: object
-                                      type: object
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    name:
-                                      type: string
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                keystoreType:
-                                  description: Type of keystore where to find private
-                                    key when using MTLS. PKCS12 and JKS are supported
-                                  type: string
-                                saslJaasConfig:
-                                  description: Additional JAAS config for SASL_TLS authentication
-                                    type
-                                  type: string
-                                saslMechanism:
-                                  description: SASL mechanism used when using SASL_TLS
-                                    authentication type
-                                  type: string
-                                truststoreSecretRef:
-                                  description: Reference to Secret holding cluster certificate
-                                    for TLS transport
-                                  properties:
-                                    additionalProperties:
-                                      additionalProperties:
-                                        type: object
-                                      type: object
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    name:
-                                      type: string
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                truststoreType:
-                                  description: Type of truststore where to find cluster
-                                    certificate for TLS transport. PKCS12 and JKS are
-                                    supported
-                                  type: string
-                                type:
-                                  description: Type of authentication method for connecting
-                                    to external Kafka broker
-                                  enum:
-                                    - NONE
-                                    - SASL_SSL
-                                    - SSL
-                                  type: string
-                              type: object
-                            ingressClassName:
-                              description: "When exposed via ingress, sets the ingressClassName\
-                              \ property in the Ingress resources"
-                              type: string
-                            install:
-                              description: Install Kafka broker or reuse an existing
-                                instance? Default to true
-                              type: boolean
-                            persistent:
-                              description: Use persistent storage or ephemeral one?
-                                Default to false
-                              type: boolean
-                            resources:
-                              description: Kubernetes resource requirements for Kafka
-                                broker
-                              properties:
-                                claims:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                  type: array
-                                limits:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    x-kubernetes-int-or-string: true
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    x-kubernetes-int-or-string: true
-                                  type: object
-                              type: object
-                            schemaRegistry:
-                              description: Specification of Schema registry connection
-                              properties:
-                                confluentCompatibility:
-                                  description: Whether you should use the Confluent
-                                    compatibility API layer. Default to true.
-                                  type: boolean
-                                credentialsSource:
-                                  description: The source of credentials for authenticating
-                                    the connection to Schema Registry. Defaults to USER_INFO.
-                                  type: string
-                                url:
-                                  description: The URL for accessing external Schema
-                                    Registry
-                                  type: string
-                                username:
-                                  description: The username for authenticating the connection
-                                    to Schema Registry
-                                  type: string
-                              type: object
-                            url:
-                              description: The URL to use for either exposing embedded
-                                Kafka broker or connecting external broker
-                              type: string
-                            volumeSize:
-                              description: Size of persistent storage volume if persistent
-                              type: string
-                            zkResources:
-                              description: Kubernetes resource requirements for Zookeeper
-                                ensemble
-                              properties:
-                                claims:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                  type: array
-                                limits:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    x-kubernetes-int-or-string: true
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    x-kubernetes-int-or-string: true
-                                  type: object
-                              type: object
-                          type: object
-                        mqtt:
-                          description: Configuration of MQTT broker access
-                          properties:
-                            password:
-                              description: The password to use for authenticating to
-                                the broker
-                              type: string
-                            url:
-                              description: The URL to use for connecting to the broker
-                              type: string
-                            username:
-                              description: The username to use for authenticating to
-                                the broker
-                              type: string
-                          type: object
-                        nats:
-                          description: Configuration of NATS broker access
-                          properties:
-                            password:
-                              description: The password to use for authenticating to
-                                the broker
-                              type: string
-                            url:
-                              description: The URL to use for connecting to the broker
-                              type: string
-                            username:
-                              description: The username to use for authenticating to
-                                the broker
-                              type: string
-                          type: object
-                        sns:
-                          description: Configuration of Amazon SNS access
-                          properties:
-                            credentialsProfile:
-                              description: The name of profile to use for connecting
-                                when using profile credentials type
-                              type: string
-                            credentialsSecretRef:
-                              description: A secret reference holding the credentials
-                                information for the chosen type
-                              properties:
-                                additionalProperties:
-                                  additionalProperties:
-                                    type: object
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                name:
-                                  type: string
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            credentialsType:
-                              description: The type of credentials provider to use for
-                                connecting. Either env-variable or profile.
-                              enum:
-                                - ENV_VARIABLE
-                                - PROFILE
-                              type: string
-                            region:
-                              description: The Amazon region to use for connecting to
-                                this service
-                              type: string
-                          type: object
-                        sqs:
-                          description: Configuration of Amazon SQS access
-                          properties:
-                            credentialsProfile:
-                              description: The name of profile to use for connecting
-                                when using profile credentials type
-                              type: string
-                            credentialsSecretRef:
-                              description: A secret reference holding the credentials
-                                information for the chosen type
-                              properties:
-                                additionalProperties:
-                                  additionalProperties:
-                                    type: object
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                name:
-                                  type: string
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            credentialsType:
-                              description: The type of credentials provider to use for
-                                connecting. Either env-variable or profile.
-                              enum:
-                                - ENV_VARIABLE
-                                - PROFILE
-                              type: string
-                            region:
-                              description: The Amazon region to use for connecting to
-                                this service
-                              type: string
-                          type: object
-                        ws:
-                          description: Configuration of WebSocket ingress
-                          properties:
-                            annotations:
-                              additionalProperties:
+                          schemaRegistry:
+                            description: Specification of Schema registry connection
+                            properties:
+                              confluentCompatibility:
+                                description: Whether you should use the Confluent
+                                  compatibility API layer. Default to true.
+                                type: boolean
+                              credentialsSource:
+                                description: The source of credentials for authenticating
+                                  the connection to Schema Registry. Defaults to USER_INFO.
                                 type: string
-                              description: Annotations to apply to Ingress if created
-                              type: object
-                            className:
-                              description: "When exposed, sets the ingressClassName\
-                              \ property"
-                              type: string
-                            expose:
-                              description: Whether Ingress should be exposed (ie. created)
-                              type: boolean
-                            generateCert:
-                              description: Whether operator should generate self-signed
-                                certificate for this ingress
-                              type: boolean
-                            secretRef:
-                              description: Existing Secret holding TLS key and certificate
-                                name
-                              type: string
-                          type: object
-                      type: object
-                    microcksHub:
-                      description: Configuration for Microcks Hub related features
-                      properties:
-                        allowedRoles:
-                          type: string
-                        enabled:
-                          description: Enable/disable this feature. Default is false.
-                          type: boolean
-                      type: object
-                    repositoryFilter:
-                      description: Configuration for repository filtering features
-                      properties:
-                        enabled:
-                          description: Enable/disable this feature. Default is false
-                          type: boolean
-                        labelKey:
-                          description: The label key to consider for repository filtering
-                          type: string
-                        labelLabel:
-                          description: The label of label used for repository filtering
-                          type: string
-                        labelList:
-                          description: "The list of labels (separated by ,) to display\
-                          \ on services list"
-                          type: string
-                      type: object
-                    repositoryTenancy:
-                      description: Configuration for repository tenancy features
-                      properties:
-                        artifactImportAllowedRoles:
-                          description: "The list of roles (separated by ,) that are\
-                          \ allowed to import artifacts"
-                          type: string
-                        enabled:
-                          description: Enable/disable this feature. Default is false
-                          type: boolean
-                      type: object
-                  type: object
-                keycloak:
-                  description: Configuration of Keycloak access and/or install
-                  properties:
-                    image:
-                      description: The container image to use for Keycloak
-                      properties:
-                        digest:
-                          description: The digest of the image
-                          type: string
-                        registry:
-                          description: "The registry where to pull this image (docker.io,\
-                          \ quay.io, internal one...)"
-                          type: string
-                        repository:
-                          description: The repository name of the image
-                          type: string
-                        tag:
-                          description: The tag of the image
-                          type: string
-                      type: object
-                    ingress:
-                      description: Configuration to apply to Ingress if created
-                      properties:
-                        annotations:
-                          additionalProperties:
+                              url:
+                                description: The URL for accessing external Schema
+                                  Registry
+                                type: string
+                              username:
+                                description: The username for authenticating the connection
+                                  to Schema Registry
+                                type: string
+                            type: object
+                          url:
+                            description: The URL to use for either exposing embedded
+                              Kafka broker or connecting external broker
                             type: string
-                          description: Annotations to apply to Ingress if created
-                          type: object
-                        className:
-                          description: "When exposed, sets the ingressClassName property"
-                          type: string
-                        expose:
-                          description: Whether Ingress should be exposed (ie. created)
-                          type: boolean
-                        generateCert:
-                          description: Whether operator should generate self-signed
-                            certificate for this ingress
-                          type: boolean
-                        secretRef:
-                          description: Existing Secret holding TLS key and certificate
-                            name
-                          type: string
-                      type: object
-                    install:
-                      description: Install Keycloak or reuse an existing instance? Default
-                        to true.
-                      type: boolean
-                    openshift:
-                      description: Configuration of OpenShift specific settings
-                      properties:
-                        route:
-                          description: Allow configuration of settings for OpenShift
-                            routes
-                          properties:
-                            enabled:
-                              description: Whether operator should use Route API if
-                                on OpenShift
-                              type: boolean
-                            tlsCaCertificate:
-                              description: TLS CA certificate for reencrypt termination
+                          volumeSize:
+                            description: Size of persistent storage volume if persistent
+                            type: string
+                          zkResources:
+                            description: Kubernetes resource requirements for Zookeeper
+                              ensemble
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                        type: object
+                      mqtt:
+                        description: Configuration of MQTT broker access
+                        properties:
+                          password:
+                            description: The password to use for authenticating to
+                              the broker
+                            type: string
+                          url:
+                            description: The URL to use for connecting to the broker
+                            type: string
+                          username:
+                            description: The username to use for authenticating to
+                              the broker
+                            type: string
+                        type: object
+                      nats:
+                        description: Configuration of NATS broker access
+                        properties:
+                          password:
+                            description: The password to use for authenticating to
+                              the broker
+                            type: string
+                          url:
+                            description: The URL to use for connecting to the broker
+                            type: string
+                          username:
+                            description: The username to use for authenticating to
+                              the broker
+                            type: string
+                        type: object
+                      sns:
+                        description: Configuration of Amazon SNS access
+                        properties:
+                          credentialsProfile:
+                            description: The name of profile to use for connecting
+                              when using profile credentials type
+                            type: string
+                          credentialsSecretRef:
+                            description: A secret reference holding the credentials
+                              information for the chosen type
+                            properties:
+                              additionalProperties:
+                                additionalProperties:
+                                  type: object
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              name:
+                                type: string
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          credentialsType:
+                            description: The type of credentials provider to use for
+                              connecting. Either env-variable or profile.
+                            enum:
+                            - ENV_VARIABLE
+                            - PROFILE
+                            type: string
+                          region:
+                            description: The Amazon region to use for connecting to
+                              this service
+                            type: string
+                        type: object
+                      sqs:
+                        description: Configuration of Amazon SQS access
+                        properties:
+                          credentialsProfile:
+                            description: The name of profile to use for connecting
+                              when using profile credentials type
+                            type: string
+                          credentialsSecretRef:
+                            description: A secret reference holding the credentials
+                              information for the chosen type
+                            properties:
+                              additionalProperties:
+                                additionalProperties:
+                                  type: object
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              name:
+                                type: string
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          credentialsType:
+                            description: The type of credentials provider to use for
+                              connecting. Either env-variable or profile.
+                            enum:
+                            - ENV_VARIABLE
+                            - PROFILE
+                            type: string
+                          region:
+                            description: The Amazon region to use for connecting to
+                              this service
+                            type: string
+                        type: object
+                      ws:
+                        description: Configuration of WebSocket ingress
+                        properties:
+                          annotations:
+                            additionalProperties:
                               type: string
-                            tlsCertificate:
-                              description: TLS certificate for reencrypt termination
-                              type: string
-                            tlsDestinationCaCertificate:
-                              description: TLS destination CA certificate for reencrypt
-                                termination
-                              type: string
-                            tlsInsecureEdgeTerminationPolicy:
-                              description: TLS insecure edge termination policy
-                              type: string
-                            tlsKey:
-                              description: TLS private key for reencrypt termination
-                              type: string
-                            tlsTermination:
-                              description: "Type of OpenShift route to create ('edge',\
-                              \ 'passthrough', 'reencrypt'"
-                              type: string
-                          type: object
-                      type: object
-                    operatorServiceAccountEnabled:
-                      description: Flag to enable/disable the Service Account dedicated
-                        to the operator for connecting to Keycloak. Default to true.
-                      type: boolean
-                    persistent:
-                      description: Use persistent storage or ephemeral one? Default
-                        to true.
-                      type: boolean
-                    postgresImage:
-                      description: The container image to use for PostgreSQL database
-                      properties:
-                        digest:
-                          description: The digest of the image
-                          type: string
-                        registry:
-                          description: "The registry where to pull this image (docker.io,\
+                            description: Annotations to apply to Ingress if created
+                            type: object
+                          className:
+                            description: "When exposed, sets the ingressClassName\
+                              \ property"
+                            type: string
+                          expose:
+                            description: Whether Ingress should be exposed (ie. created)
+                            type: boolean
+                          generateCert:
+                            description: Whether operator should generate self-signed
+                              certificate for this ingress
+                            type: boolean
+                          secretRef:
+                            description: Existing Secret holding TLS key and certificate
+                              name
+                            type: string
+                        type: object
+                    type: object
+                  microcksHub:
+                    description: Configuration for Microcks Hub related features
+                    properties:
+                      allowedRoles:
+                        type: string
+                      enabled:
+                        description: Enable/disable this feature. Default is false.
+                        type: boolean
+                    type: object
+                  repositoryFilter:
+                    description: Configuration for repository filtering features
+                    properties:
+                      enabled:
+                        description: Enable/disable this feature. Default is false
+                        type: boolean
+                      labelKey:
+                        description: The label key to consider for repository filtering
+                        type: string
+                      labelLabel:
+                        description: The label of label used for repository filtering
+                        type: string
+                      labelList:
+                        description: "The list of labels (separated by ,) to display\
+                          \ on services list"
+                        type: string
+                    type: object
+                  repositoryTenancy:
+                    description: Configuration for repository tenancy features
+                    properties:
+                      artifactImportAllowedRoles:
+                        description: "The list of roles (separated by ,) that are\
+                          \ allowed to import artifacts"
+                        type: string
+                      enabled:
+                        description: Enable/disable this feature. Default is false
+                        type: boolean
+                    type: object
+                type: object
+              keycloak:
+                description: Configuration of Keycloak access and/or install
+                properties:
+                  image:
+                    description: The container image to use for Keycloak
+                    properties:
+                      digest:
+                        description: The digest of the image
+                        type: string
+                      registry:
+                        description: "The registry where to pull this image (docker.io,\
                           \ quay.io, internal one...)"
+                        type: string
+                      repository:
+                        description: The repository name of the image
+                        type: string
+                      tag:
+                        description: The tag of the image
+                        type: string
+                    type: object
+                  ingress:
+                    description: Configuration to apply to Ingress if created
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        repository:
-                          description: The repository name of the image
-                          type: string
-                        tag:
-                          description: The tag of the image
-                          type: string
-                      type: object
-                    privateUrl:
-                      description: "A private URL - a full URL here - used by the Microcks\
+                        description: Annotations to apply to Ingress if created
+                        type: object
+                      className:
+                        description: "When exposed, sets the ingressClassName property"
+                        type: string
+                      expose:
+                        description: Whether Ingress should be exposed (ie. created)
+                        type: boolean
+                      generateCert:
+                        description: Whether operator should generate self-signed
+                          certificate for this ingress
+                        type: boolean
+                      secretRef:
+                        description: Existing Secret holding TLS key and certificate
+                          name
+                        type: string
+                    type: object
+                  install:
+                    description: Install Keycloak or reuse an existing instance? Default
+                      to true.
+                    type: boolean
+                  openshift:
+                    description: Configuration of OpenShift specific settings
+                    properties:
+                      route:
+                        description: Allow configuration of settings for OpenShift
+                          routes
+                        properties:
+                          enabled:
+                            description: Whether operator should use Route API if
+                              on OpenShift
+                            type: boolean
+                          tlsCaCertificate:
+                            description: TLS CA certificate for reencrypt termination
+                            type: string
+                          tlsCertificate:
+                            description: TLS certificate for reencrypt termination
+                            type: string
+                          tlsDestinationCaCertificate:
+                            description: TLS destination CA certificate for reencrypt
+                              termination
+                            type: string
+                          tlsInsecureEdgeTerminationPolicy:
+                            description: TLS insecure edge termination policy
+                            type: string
+                          tlsKey:
+                            description: TLS private key for reencrypt termination
+                            type: string
+                          tlsTermination:
+                            description: "Type of OpenShift route to create ('edge',\
+                              \ 'passthrough', 'reencrypt'"
+                            type: string
+                        type: object
+                    type: object
+                  operatorServiceAccountEnabled:
+                    description: Flag to enable/disable the Service Account dedicated
+                      to the operator for connecting to Keycloak. Default to true.
+                    type: boolean
+                  persistent:
+                    description: Use persistent storage or ephemeral one? Default
+                      to true.
+                    type: boolean
+                  postgresImage:
+                    description: The container image to use for PostgreSQL database
+                    properties:
+                      digest:
+                        description: The digest of the image
+                        type: string
+                      registry:
+                        description: "The registry where to pull this image (docker.io,\
+                          \ quay.io, internal one...)"
+                        type: string
+                      repository:
+                        description: The repository name of the image
+                        type: string
+                      tag:
+                        description: The tag of the image
+                        type: string
+                    type: object
+                  privateUrl:
+                    description: "A private URL - a full URL here - used by the Microcks\
                       \ component to internally join Keycloak. This is also known\
                       \ as `backendUrl` in Keycloak. When specified, the `keycloak.url`\
                       \ is used as `frontendUrl` in Keycloak terms."
+                    type: string
+                  pvcAnnotations:
+                    additionalProperties:
                       type: string
-                    pvcAnnotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations to be added to managed Persistent Volume
-                        Claim
-                      type: object
-                    realm:
-                      description: Keycloak realm to use for authentication on Microcks
-                      type: string
-                    serviceAccount:
-                      description: Service Account for connecting external services
-                        to Microcks
-                      type: string
-                    serviceAccountCredentials:
-                      description: Service Account credentials for external services
-                      type: string
-                    storageClassName:
-                      description: Name of storage class to use if not relying on default
-                      type: string
-                    url:
-                      description: Keycloak root URL to use for access and Ingress if
-                        created
-                      type: string
-                    volumeSize:
-                      description: Size of persistent storage volume if persistent
-                      type: string
-                  type: object
-                microcks:
-                  description: Configuration of main Microcks service
-                  properties:
-                    env:
-                      description: Environment variables for Microcks service
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            type: string
-                          valueFrom:
-                            properties:
-                              configMapKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                type: object
-                              fieldRef:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldPath:
-                                    type: string
-                                type: object
-                              resourceFieldRef:
-                                properties:
-                                  containerName:
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    type: string
-                                type: object
-                              secretKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                type: object
-                            type: object
-                        type: object
-                      type: array
-                    extraProperties:
-                      additionalProperties:
-                        x-kubernetes-preserve-unknown-fields: true
-                      description: Extra properties to integration into application-extra
-                        configuration
-                      type: object
-                    grpcIngress:
-                      description: Configuration to apply to Ingress for gRPC if creates
+                    description: Annotations to be added to managed Persistent Volume
+                      Claim
+                    type: object
+                  realm:
+                    description: Keycloak realm to use for authentication on Microcks
+                    type: string
+                  serviceAccount:
+                    description: Service Account for connecting external services
+                      to Microcks
+                    type: string
+                  serviceAccountCredentials:
+                    description: Service Account credentials for external services
+                    type: string
+                  storageClassName:
+                    description: Name of storage class to use if not relying on default
+                    type: string
+                  url:
+                    description: Keycloak root URL to use for access and Ingress if
+                      created
+                    type: string
+                  volumeSize:
+                    description: Size of persistent storage volume if persistent
+                    type: string
+                type: object
+              microcks:
+                description: Configuration of main Microcks service
+                properties:
+                  env:
+                    description: Environment variables for Microcks service
+                    items:
                       properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Annotations to apply to Ingress if created
-                          type: object
-                        className:
-                          description: "When exposed, sets the ingressClassName property"
-                          type: string
-                        expose:
-                          description: Whether Ingress should be exposed (ie. created)
-                          type: boolean
-                        generateCert:
-                          description: Whether operator should generate self-signed
-                            certificate for this ingress
-                          type: boolean
-                        secretRef:
-                          description: Existing Secret holding TLS key and certificate
-                            name
-                          type: string
-                      type: object
-                    image:
-                      description: The container image to use for Microcks service
-                      properties:
-                        digest:
-                          description: The digest of the image
-                          type: string
-                        registry:
-                          description: "The registry where to pull this image (docker.io,\
-                          \ quay.io, internal one...)"
-                          type: string
-                        repository:
-                          description: The repository name of the image
-                          type: string
-                        tag:
-                          description: The tag of the image
-                          type: string
-                      type: object
-                    ingress:
-                      description: Configuration to apply to Ingress if created
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Annotations to apply to Ingress if created
-                          type: object
-                        className:
-                          description: "When exposed, sets the ingressClassName property"
-                          type: string
-                        expose:
-                          description: Whether Ingress should be exposed (ie. created)
-                          type: boolean
-                        generateCert:
-                          description: Whether operator should generate self-signed
-                            certificate for this ingress
-                          type: boolean
-                        secretRef:
-                          description: Existing Secret holding TLS key and certificate
-                            name
-                          type: string
-                      type: object
-                    logLevel:
-                      description: Allow configuration of logging level. Defaults to
-                        INFO
-                      enum:
-                        - DEBUG
-                        - ERROR
-                        - INFO
-                        - WARN
-                      type: string
-                    mockInvocationStats:
-                      description: Enable/disable statistics for mocks invocation. Defaults
-                        to true
-                      type: boolean
-                    openshift:
-                      description: Configuration of OpenShift specific settings
-                      properties:
-                        route:
-                          description: Allow configuration of settings for OpenShift
-                            routes
-                          properties:
-                            enabled:
-                              description: Whether operator should use Route API if
-                                on OpenShift
-                              type: boolean
-                            tlsCaCertificate:
-                              description: TLS CA certificate for reencrypt termination
-                              type: string
-                            tlsCertificate:
-                              description: TLS certificate for reencrypt termination
-                              type: string
-                            tlsDestinationCaCertificate:
-                              description: TLS destination CA certificate for reencrypt
-                                termination
-                              type: string
-                            tlsInsecureEdgeTerminationPolicy:
-                              description: TLS insecure edge termination policy
-                              type: string
-                            tlsKey:
-                              description: TLS private key for reencrypt termination
-                              type: string
-                            tlsTermination:
-                              description: "Type of OpenShift route to create ('edge',\
-                              \ 'passthrough', 'reencrypt'"
-                              type: string
-                          type: object
-                      type: object
-                    replicas:
-                      description: Number of desired pods for Microcks service
-                      type: integer
-                    resources:
-                      description: Kubernetes resource requirements for Microcks service
-                      properties:
-                        claims:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          type: array
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            x-kubernetes-int-or-string: true
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            x-kubernetes-int-or-string: true
-                          type: object
-                      type: object
-                    url:
-                      description: The URL to use for exposing Microcks main ingress
-                      type: string
-                  type: object
-                mongodb:
-                  description: Configuration of MongoDB access and/or install
-                  properties:
-                    database:
-                      description: MongoDB database name in case you're reusing existing
-                        one. Only if install if false.
-                      type: string
-                    image:
-                      description: The container image to use for MongoDB
-                      properties:
-                        digest:
-                          description: The digest of the image
-                          type: string
-                        registry:
-                          description: "The registry where to pull this image (docker.io,\
-                          \ quay.io, internal one...)"
-                          type: string
-                        repository:
-                          description: The repository name of the image
-                          type: string
-                        tag:
-                          description: The tag of the image
-                          type: string
-                      type: object
-                    install:
-                      description: Install MongoDB or reuse an existing instance? Default
-                        to true.
-                      type: boolean
-                    persistent:
-                      description: Use persistent storage or ephemeral one? Default
-                        to true
-                      type: boolean
-                    pvcAnnotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations to be added to managed Persistent Volume
-                        Claim
-                      type: object
-                    resources:
-                      description: Kubernetes resource requirements for MongoDB
-                      properties:
-                        claims:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          type: array
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            x-kubernetes-int-or-string: true
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            x-kubernetes-int-or-string: true
-                          type: object
-                      type: object
-                    secretRef:
-                      description: Reference of a Secret containing username and password
-                        keys for connecting to existing MongoDB instance
-                      properties:
-                        additionalProperties:
-                          additionalProperties:
-                            type: object
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
                         name:
                           type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              type: object
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              type: object
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                          type: object
                       type: object
+                    type: array
+                  extraProperties:
+                    additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
-                    securityContext:
-                      description: Security context for MongoDB deployment
-                      properties:
-                        fsGroup:
-                          type: integer
-                        fsGroupChangePolicy:
-                          type: string
-                        runAsGroup:
-                          type: integer
-                        runAsNonRoot:
-                          type: boolean
-                        runAsUser:
-                          type: integer
-                        seLinuxOptions:
-                          properties:
-                            level:
-                              type: string
-                            role:
-                              type: string
-                            type:
-                              type: string
-                            user:
-                              type: string
-                          type: object
-                        seccompProfile:
-                          properties:
-                            localhostProfile:
-                              type: string
-                            type:
-                              type: string
-                          type: object
-                        supplementalGroups:
-                          items:
-                            type: integer
-                          type: array
-                        sysctls:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              value:
-                                type: string
-                            type: object
-                          type: array
-                        windowsOptions:
-                          properties:
-                            gmsaCredentialSpec:
-                              type: string
-                            gmsaCredentialSpecName:
-                              type: string
-                            hostProcess:
-                              type: boolean
-                            runAsUserName:
-                              type: string
-                          type: object
-                      type: object
-                    storageClassName:
-                      description: Name of storage class to use if not relying on default
-                      type: string
-                    uri:
-                      description: MongoDB root URI to use for access
-                      type: string
-                    uriParameters:
-                      description: Parameters added to MongoDB URI connection string.
-                        Only if install if false.
-                      type: string
-                    volumeSize:
-                      description: Size of persistent storage volume if persistent
-                      type: string
-                  type: object
-                postman:
-                  description: Configuration of Postman runtime
-                  properties:
-                    image:
-                      description: The container image to use for Postman runtime
-                      properties:
-                        digest:
-                          description: The digest of the image
-                          type: string
-                        registry:
-                          description: "The registry where to pull this image (docker.io,\
-                          \ quay.io, internal one...)"
-                          type: string
-                        repository:
-                          description: The repository name of the image
-                          type: string
-                        tag:
-                          description: The tag of the image
-                          type: string
-                      type: object
-                    replicas:
-                      description: Number of desired pods for Postman runtime
-                      type: integer
-                  type: object
-                version:
-                  description: The Microcks version
-                  type: string
-              type: object
-            status:
-              properties:
-                additionalProperties:
-                  additionalProperties:
+                    description: Extra properties to integration into application-extra
+                      configuration
                     type: object
-                  type: object
-                conditions:
-                  description: List of status conditions
-                  items:
+                  grpcIngress:
+                    description: Configuration to apply to Ingress for gRPC if creates
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations to apply to Ingress if created
+                        type: object
+                      className:
+                        description: "When exposed, sets the ingressClassName property"
+                        type: string
+                      expose:
+                        description: Whether Ingress should be exposed (ie. created)
+                        type: boolean
+                      generateCert:
+                        description: Whether operator should generate self-signed
+                          certificate for this ingress
+                        type: boolean
+                      secretRef:
+                        description: Existing Secret holding TLS key and certificate
+                          name
+                        type: string
+                    type: object
+                  image:
+                    description: The container image to use for Microcks service
+                    properties:
+                      digest:
+                        description: The digest of the image
+                        type: string
+                      registry:
+                        description: "The registry where to pull this image (docker.io,\
+                          \ quay.io, internal one...)"
+                        type: string
+                      repository:
+                        description: The repository name of the image
+                        type: string
+                      tag:
+                        description: The tag of the image
+                        type: string
+                    type: object
+                  ingress:
+                    description: Configuration to apply to Ingress if created
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations to apply to Ingress if created
+                        type: object
+                      className:
+                        description: "When exposed, sets the ingressClassName property"
+                        type: string
+                      expose:
+                        description: Whether Ingress should be exposed (ie. created)
+                        type: boolean
+                      generateCert:
+                        description: Whether operator should generate self-signed
+                          certificate for this ingress
+                        type: boolean
+                      secretRef:
+                        description: Existing Secret holding TLS key and certificate
+                          name
+                        type: string
+                    type: object
+                  logLevel:
+                    description: Allow configuration of logging level. Defaults to
+                      INFO
+                    enum:
+                    - DEBUG
+                    - ERROR
+                    - INFO
+                    - WARN
+                    type: string
+                  mockInvocationStats:
+                    description: Enable/disable statistics for mocks invocation. Defaults
+                      to true
+                    type: boolean
+                  openshift:
+                    description: Configuration of OpenShift specific settings
+                    properties:
+                      route:
+                        description: Allow configuration of settings for OpenShift
+                          routes
+                        properties:
+                          enabled:
+                            description: Whether operator should use Route API if
+                              on OpenShift
+                            type: boolean
+                          tlsCaCertificate:
+                            description: TLS CA certificate for reencrypt termination
+                            type: string
+                          tlsCertificate:
+                            description: TLS certificate for reencrypt termination
+                            type: string
+                          tlsDestinationCaCertificate:
+                            description: TLS destination CA certificate for reencrypt
+                              termination
+                            type: string
+                          tlsInsecureEdgeTerminationPolicy:
+                            description: TLS insecure edge termination policy
+                            type: string
+                          tlsKey:
+                            description: TLS private key for reencrypt termination
+                            type: string
+                          tlsTermination:
+                            description: "Type of OpenShift route to create ('edge',\
+                              \ 'passthrough', 'reencrypt'"
+                            type: string
+                        type: object
+                    type: object
+                  replicas:
+                    description: Number of desired pods for Microcks service
+                    type: integer
+                  resources:
+                    description: Kubernetes resource requirements for Microcks service
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  url:
+                    description: The URL to use for exposing Microcks main ingress
+                    type: string
+                type: object
+              mongodb:
+                description: Configuration of MongoDB access and/or install
+                properties:
+                  database:
+                    description: MongoDB database name in case you're reusing existing
+                      one. Only if install if false.
+                    type: string
+                  image:
+                    description: The container image to use for MongoDB
+                    properties:
+                      digest:
+                        description: The digest of the image
+                        type: string
+                      registry:
+                        description: "The registry where to pull this image (docker.io,\
+                          \ quay.io, internal one...)"
+                        type: string
+                      repository:
+                        description: The repository name of the image
+                        type: string
+                      tag:
+                        description: The tag of the image
+                        type: string
+                    type: object
+                  install:
+                    description: Install MongoDB or reuse an existing instance? Default
+                      to true.
+                    type: boolean
+                  persistent:
+                    description: Use persistent storage or ephemeral one? Default
+                      to true
+                    type: boolean
+                  pvcAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be added to managed Persistent Volume
+                      Claim
+                    type: object
+                  resources:
+                    description: Kubernetes resource requirements for MongoDB
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  secretRef:
+                    description: Reference of a Secret containing username and password
+                      keys for connecting to existing MongoDB instance
                     properties:
                       additionalProperties:
                         additionalProperties:
                           type: object
                         type: object
-                      lastTransitionTime:
-                        description: "Last time the condition of a type changed from\
-                        \ one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',\
-                        \ in the UTC time zone"
-                        type: string
-                      message:
-                        description: Human-readable message indicating details about
-                          the condition's last transition
-                        type: string
-                      reason:
-                        description: The reason for the condition's last transition
-                          (a single word in CamelCase)
-                        type: string
-                      status:
-                        description: The status of the condition
-                        enum:
-                          - DEPLOYING
-                          - ERROR
-                          - PREEXISTING
-                          - READY
-                          - UNKNOWN
-                        type: string
-                      type:
-                        description: "The unique identifier of a condition, used to\
-                        \ distinguish between other conditions in the resource"
+                        x-kubernetes-preserve-unknown-fields: true
+                      name:
                         type: string
                     type: object
-                  type: array
-                keycloakUrl:
-                  description: The URL to access Keycloak once installation completed
-                  type: string
-                message:
-                  type: string
-                microcksUrl:
-                  description: The URL to access Microcks once installation completed
-                  type: string
-                observedGeneration:
-                  description: Reconciled generation
-                  type: integer
-                status:
-                  description: Global status of the reconciliation
-                  enum:
-                    - DEPLOYING
-                    - ERROR
-                    - PREEXISTING
-                    - READY
-                    - UNKNOWN
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    x-kubernetes-preserve-unknown-fields: true
+                  securityContext:
+                    description: Security context for MongoDB deployment
+                    properties:
+                      fsGroup:
+                        type: integer
+                      fsGroupChangePolicy:
+                        type: string
+                      runAsGroup:
+                        type: integer
+                      runAsNonRoot:
+                        type: boolean
+                      runAsUser:
+                        type: integer
+                      seLinuxOptions:
+                        properties:
+                          level:
+                            type: string
+                          role:
+                            type: string
+                          type:
+                            type: string
+                          user:
+                            type: string
+                        type: object
+                      seccompProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        type: object
+                      supplementalGroups:
+                        items:
+                          type: integer
+                        type: array
+                      sysctls:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      windowsOptions:
+                        properties:
+                          gmsaCredentialSpec:
+                            type: string
+                          gmsaCredentialSpecName:
+                            type: string
+                          hostProcess:
+                            type: boolean
+                          runAsUserName:
+                            type: string
+                        type: object
+                    type: object
+                  storageClassName:
+                    description: Name of storage class to use if not relying on default
+                    type: string
+                  uri:
+                    description: MongoDB root URI to use for access
+                    type: string
+                  uriParameters:
+                    description: Parameters added to MongoDB URI connection string.
+                      Only if install if false.
+                    type: string
+                  volumeSize:
+                    description: Size of persistent storage volume if persistent
+                    type: string
+                type: object
+              postman:
+                description: Configuration of Postman runtime
+                properties:
+                  image:
+                    description: The container image to use for Postman runtime
+                    properties:
+                      digest:
+                        description: The digest of the image
+                        type: string
+                      registry:
+                        description: "The registry where to pull this image (docker.io,\
+                          \ quay.io, internal one...)"
+                        type: string
+                      repository:
+                        description: The repository name of the image
+                        type: string
+                      tag:
+                        description: The tag of the image
+                        type: string
+                    type: object
+                  replicas:
+                    description: Number of desired pods for Postman runtime
+                    type: integer
+                type: object
+              version:
+                description: The Microcks version
+                type: string
+            type: object
+          status:
+            properties:
+              additionalProperties:
+                additionalProperties:
+                  type: object
+                type: object
+              conditions:
+                description: List of status conditions
+                items:
+                  properties:
+                    additionalProperties:
+                      additionalProperties:
+                        type: object
+                      type: object
+                    lastTransitionTime:
+                      description: "Last time the condition of a type changed from\
+                        \ one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ',\
+                        \ in the UTC time zone"
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        the condition's last transition
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        (a single word in CamelCase)
+                      type: string
+                    status:
+                      description: The status of the condition
+                      enum:
+                      - DEPLOYING
+                      - ERROR
+                      - PREEXISTING
+                      - READY
+                      - UNKNOWN
+                      type: string
+                    type:
+                      description: "The unique identifier of a condition, used to\
+                        \ distinguish between other conditions in the resource"
+                      type: string
+                  type: object
+                type: array
+              keycloakUrl:
+                description: The URL to access Keycloak once installation completed
+                type: string
+              message:
+                type: string
+              microcksUrl:
+                description: The URL to access Microcks once installation completed
+                type: string
+              observedGeneration:
+                description: Reconciled generation
+                type: integer
+              status:
+                description: Global status of the reconciliation
+                enum:
+                - DEPLOYING
+                - ERROR
+                - PREEXISTING
+                - READY
+                - UNKNOWN
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/src/main/resources/templates/MicrocksConfigMapDependentResource/application.properties
+++ b/operator/src/main/resources/templates/MicrocksConfigMapDependentResource/application.properties
@@ -83,7 +83,9 @@ ai-copilot.enabled={spec.features.aiCopilot.enabled ?: 'false'}
 ai-copilot.implementation={spec.features.aiCopilot.implementation}
 {#if spec.features.aiCopilot.implementation == "openai" && spec.features.aiCopilot.openai}
 ai-copilot.openai.api-key={spec.features.aiCopilot.openai.apiKey}
-ai-copilot.openai.api-url={spec.features.aiCopilot.openai.apiUrl ?: 'https://api.openai.com/'}
+{#if spec.features.aiCopilot.openai && spec.features.aiCopilot.openai.apiUrl != null}
+ai-copilot.openai.api-url={spec.features.aiCopilot.openai.apiUrl}
+{/if}
 {#if spec.features.aiCopilot.openai.timeout != null && spec.features.aiCopilot.openai.timeout != 0}
 ai-copilot.openai.timeout={spec.features.aiCopilot.openai.timeout}
 {/if}

--- a/operator/src/main/resources/templates/MicrocksConfigMapDependentResource/application.properties
+++ b/operator/src/main/resources/templates/MicrocksConfigMapDependentResource/application.properties
@@ -83,6 +83,7 @@ ai-copilot.enabled={spec.features.aiCopilot.enabled ?: 'false'}
 ai-copilot.implementation={spec.features.aiCopilot.implementation}
 {#if spec.features.aiCopilot.implementation == "openai" && spec.features.aiCopilot.openai}
 ai-copilot.openai.api-key={spec.features.aiCopilot.openai.apiKey}
+ai-copilot.openai.api-url={spec.features.aiCopilot.openai.apiUrl ?: 'https://api.openai.com/'}
 {#if spec.features.aiCopilot.openai.timeout != null && spec.features.aiCopilot.openai.timeout != 0}
 ai-copilot.openai.timeout={spec.features.aiCopilot.openai.timeout}
 {/if}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Added `apiUrl` property in the OpenAI Copilot configuration block of the Microcks Custom Resource.

- Set a default value (https://api.openai.com/) if apiUrl is not provided.
- Add `apiUrl` as a field in `OpenAISpec` and include necessary getter and setter methods.

### Related issue(s)

Fixes #111,  #114

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->