### PR TITLE
added the helm chart for the microcks

### DIFF
--- a/charts/microcks-operator/Chart.yaml
+++ b/charts/microcks-operator/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: microcks-operator
+description: Helm chart to install the Microcks Operator and CRDs
+
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - microcks
+  - operator
+  - kubernetes-operator
+home: https://microcks.io/
+sources:
+  - https://github.com/microcks/microcks-operator
+maintainers:
+  - name: Microcks Maintainers
+    url: https://github.com/microcks
+
+kubeVersion: ">=1.22.0-0"

--- a/charts/microcks-operator/templates/_helpers.tpl
+++ b/charts/microcks-operator/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{- define "microcks-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "microcks-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "microcks-operator.labels" -}}
+app.kubernetes.io/name: {{ include "microcks-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: microcks
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end -}}

--- a/charts/microcks-operator/templates/deployment.yaml
+++ b/charts/microcks-operator/templates/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "microcks-operator.fullname" . }}
+  labels:
+    {{- include "microcks-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "microcks-operator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        {{- include "microcks-operator.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ default (include "microcks-operator.fullname" .) .Values.serviceAccount.name }}
+      containers:
+        - name: microcks-operator
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: microcks-operator
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/microcks-operator/templates/role.yaml
+++ b/charts/microcks-operator/templates/role.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "microcks-operator.fullname" . }}
+  labels:
+    {{- include "microcks-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - '*'
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - '*'
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes/custom-host
+    verbs:
+      - create
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - '*'
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+      - grpcroutes
+    verbs:
+      - '*'
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - kafka.strimzi.io
+    resources:
+      - kafkas
+      - kafkatopics
+      - kafkanodepools
+    verbs:
+      - '*'
+  - apiGroups:
+      - microcks.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+{{- end }}

--- a/charts/microcks-operator/templates/rolebinding.yaml
+++ b/charts/microcks-operator/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "microcks-operator.fullname" . }}
+  labels:
+    {{- include "microcks-operator.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ default (include "microcks-operator.fullname" .) .Values.serviceAccount.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "microcks-operator.fullname" . }}
+{{- end }}

--- a/charts/microcks-operator/templates/serviceaccount.yaml
+++ b/charts/microcks-operator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default (include "microcks-operator.fullname" .) .Values.serviceAccount.name }}
+  labels:
+    {{- include "microcks-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/microcks-operator/values.yaml
+++ b/charts/microcks-operator/values.yaml
@@ -1,0 +1,31 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: quay.io/microcks/microcks-operator
+  tag: "latest"
+  pullPolicy: Always
+
+imagePullSecrets: []
+
+replicaCount: 1
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+rbac:
+  create: true
+
+# Control CRD installation
+crds:
+  create: true
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
### Description

- Add Helm chart `charts/microcks-operator` to install the Microcks Operator.
- Template ServiceAccount, Role, RoleBinding, and Deployment with standard app labels and name overrides.
- Add `_helpers.tpl` for names/labels and `values.yaml` for configurable image, replicas, resources, node selectors, tolerations, affinity, RBAC, and ServiceAccount.
- Introduce `crds.create` flag in `values.yaml` to optionally install CRDs.
  - To skip CRD installation: set `--set crds.create=false` or use `--skip-crds`.
- Deployment mirrors `deploy/operator-jvm.yaml` (env: `WATCH_NAMESPACE`, `POD_NAME`, `OPERATOR_NAME`) and supports `imagePullSecrets`.

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->