### PR TITLE
fix: mount Keycloak PostgreSQL data at official postgres path

### DIFF
--- a/operator/src/main/resources/k8s/keycloak-postgresql-deployment.yml
+++ b/operator/src/main/resources/k8s/keycloak-postgresql-deployment.yml
@@ -55,7 +55,7 @@ spec:
               value: /var/lib/postgresql/data/pgdata
           volumeMounts:
             - name: "keycloak-postgresql-data"
-              mountPath: "/var/lib/pgsql/data"
+              mountPath: "/var/lib/postgresql/data"
               subPath: pgdata
       terminationGracePeriodSeconds: 60
       volumes:


### PR DESCRIPTION
## Summary

Fixes a data-loss bug where the Keycloak PostgreSQL volume was mounted at the wrong path and never used by the official `library/postgres` image.

| Setting | Before (broken) | After |
|---------|-----------------|-------|
| Image | `library/postgres` | unchanged |
| `PGDATA` | `/var/lib/postgresql/data/pgdata` | unchanged |
| `volumeMounts.mountPath` | `/var/lib/pgsql/data` (RHEL/SCL) | `/var/lib/postgresql/data` |

With the old mount path, Postgres wrote under `PGDATA` on the container filesystem. The PVC/emptyDir at `/var/lib/pgsql/data` stayed empty, so **`keycloak.persistent: true` did not persist Keycloak DB data** across pod restarts.

This matches the already-correct Helm chart layout in `microcks/microcks` (`mountPath: /var/lib/postgresql/data` + `subPath: pgdata` + same `PGDATA`).

## Related

- Closes #295
- Partial earlier change in #10 / microcks/microcks#1269 added `PGDATA` + `subPath` for OpenShift permissions but left the RHEL `mountPath` in place

## Test plan

- [ ] Deploy a `Microcks` CR with `keycloak.install: true` and `keycloak.persistent: true`
- [ ] Confirm pod mount: `kubectl exec … -- df -h /var/lib/postgresql/data` (or inspect Deployment volumeMounts)
- [ ] Create a Keycloak user / mutate realm data
- [ ] Delete the Keycloak PostgreSQL pod and verify data still present after recreate
- [ ] Optionally confirm volume contents are non-empty under the PVC